### PR TITLE
Add ResolverEndpoint reference to ResolverRule

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-06-22T23:02:05Z"
+  build_date: "2026-06-23T20:47:28Z"
   build_hash: 2ae5d2cfadaa2a10b2ccb9e73a111b2a91c36642
-  go_version: go1.26.4
+  go_version: go1.26.0
   version: v0.60.0
-api_directory_checksum: ee479069f0fe4c0805dbcf20d88106166fa020dc
+api_directory_checksum: 29fbff0a4e9d64c4d9a8933795952311850a362a
 api_version: v1alpha1
-aws_sdk_go_version: v1.32.6
+aws_sdk_go_version: v1.34.0
 generator_config_info:
-  file_checksum: adad3bdc2f38b0f330b1b79fe07c5c74cdbedfae
+  file_checksum: e01984c636ad86a23d6a55a828be405c70902bbf
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -103,6 +103,10 @@ resources:
         is_primary_key: true
         print:
           name: ID
+      ResolverEndpointID:
+        references:
+          resource: ResolverEndpoint
+          path: Status.ID
       Associations:
         custom_field:
           list_of: ResolverRuleAssociation

--- a/apis/v1alpha1/resolver_rule.go
+++ b/apis/v1alpha1/resolver_rule.go
@@ -44,7 +44,8 @@ type ResolverRuleSpec struct {
 	Name *string `json:"name,omitempty"`
 	// The ID of the outbound Resolver endpoint that you want to use to route DNS
 	// queries to the IP addresses that you specify in TargetIps.
-	ResolverEndpointID *string `json:"resolverEndpointID,omitempty"`
+	ResolverEndpointID  *string                                  `json:"resolverEndpointID,omitempty"`
+	ResolverEndpointRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"resolverEndpointRef,omitempty"`
 	// When you want to forward DNS queries for specified domain name to resolvers
 	// on your network, specify FORWARD.
 	//

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -1641,6 +1641,11 @@ func (in *ResolverRuleSpec) DeepCopyInto(out *ResolverRuleSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ResolverEndpointRef != nil {
+		in, out := &in.ResolverEndpointRef, &out.ResolverEndpointRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.RuleType != nil {
 		in, out := &in.RuleType, &out.RuleType
 		*out = new(string)

--- a/config/crd/bases/route53resolver.services.k8s.aws_resolverrules.yaml
+++ b/config/crd/bases/route53resolver.services.k8s.aws_resolverrules.yaml
@@ -96,6 +96,23 @@ spec:
                   The ID of the outbound Resolver endpoint that you want to use to route DNS
                   queries to the IP addresses that you specify in TargetIps.
                 type: string
+              resolverEndpointRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               ruleType:
                 description: |-
                   When you want to forward DNS queries for specified domain name to resolvers

--- a/generator.yaml
+++ b/generator.yaml
@@ -103,6 +103,10 @@ resources:
         is_primary_key: true
         print:
           name: ID
+      ResolverEndpointID:
+        references:
+          resource: ResolverEndpoint
+          path: Status.ID
       Associations:
         custom_field:
           list_of: ResolverRuleAssociation

--- a/helm/crds/route53resolver.services.k8s.aws_resolverrules.yaml
+++ b/helm/crds/route53resolver.services.k8s.aws_resolverrules.yaml
@@ -96,6 +96,23 @@ spec:
                   The ID of the outbound Resolver endpoint that you want to use to route DNS
                   queries to the IP addresses that you specify in TargetIps.
                 type: string
+              resolverEndpointRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               ruleType:
                 description: |-
                   When you want to forward DNS queries for specified domain name to resolvers

--- a/pkg/resource/resolver_rule/delta.go
+++ b/pkg/resource/resolver_rule/delta.go
@@ -70,6 +70,9 @@ func newResourceDelta(
 			delta.Add("Spec.ResolverEndpointID", a.ko.Spec.ResolverEndpointID, b.ko.Spec.ResolverEndpointID)
 		}
 	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.ResolverEndpointRef, b.ko.Spec.ResolverEndpointRef) {
+		delta.Add("Spec.ResolverEndpointRef", a.ko.Spec.ResolverEndpointRef, b.ko.Spec.ResolverEndpointRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.RuleType, b.ko.Spec.RuleType) {
 		delta.Add("Spec.RuleType", a.ko.Spec.RuleType, b.ko.Spec.RuleType)
 	} else if a.ko.Spec.RuleType != nil && b.ko.Spec.RuleType != nil {

--- a/pkg/resource/resolver_rule/references.go
+++ b/pkg/resource/resolver_rule/references.go
@@ -17,9 +17,15 @@ package resolver_rule
 
 import (
 	"context"
+	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
+	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
 	svcapitypes "github.com/aws-controllers-k8s/route53resolver-controller/apis/v1alpha1"
@@ -31,6 +37,10 @@ import (
 // values.
 func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) acktypes.AWSResource {
 	ko := rm.concreteResource(res).ko.DeepCopy()
+
+	if ko.Spec.ResolverEndpointRef != nil {
+		ko.Spec.ResolverEndpointID = nil
+	}
 
 	return &resource{ko}
 }
@@ -47,11 +57,116 @@ func (rm *resourceManager) ResolveReferences(
 	apiReader client.Reader,
 	res acktypes.AWSResource,
 ) (acktypes.AWSResource, bool, error) {
-	return res, false, nil
+	ko := rm.concreteResource(res).ko
+
+	resourceHasReferences := false
+	err := validateReferenceFields(ko)
+	if fieldHasReferences, err := rm.resolveReferenceForResolverEndpointID(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	return &resource{ko}, resourceHasReferences, err
 }
 
 // validateReferenceFields validates the reference field and corresponding
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.ResolverRule) error {
+
+	if ko.Spec.ResolverEndpointRef != nil && ko.Spec.ResolverEndpointID != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("ResolverEndpointID", "ResolverEndpointRef")
+	}
+	return nil
+}
+
+// resolveReferenceForResolverEndpointID reads the resource referenced
+// from ResolverEndpointRef field and sets the ResolverEndpointID
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForResolverEndpointID(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.ResolverRule,
+) (hasReferences bool, err error) {
+	if ko.Spec.ResolverEndpointRef != nil && ko.Spec.ResolverEndpointRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.ResolverEndpointRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: ResolverEndpointRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &svcapitypes.ResolverEndpoint{}
+		if err := getReferencedResourceState_ResolverEndpoint(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.ResolverEndpointID = (*string)(obj.Status.ID)
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_ResolverEndpoint looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_ResolverEndpoint(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *svcapitypes.ResolverEndpoint,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"ResolverEndpoint",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"ResolverEndpoint",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"ResolverEndpoint",
+			namespace, name)
+	}
+	if obj.Status.ID == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"ResolverEndpoint",
+			namespace, name,
+			"Status.ID")
+	}
 	return nil
 }


### PR DESCRIPTION
Description of changes:
Adds a cross-resource reference from `ResolverRule.resolverEndpointID` to the ACK `route53resolver/ResolverEndpoint` resource, allowing the endpoint to be resolved via `resolverEndpointRef`.

This mirrors the existing same-service reference patterns (e.g. `ResolverRuleAssociation.resolverRuleID` -> `ResolverRule`, `ResolverQueryLogConfigAssociation.resolverQueryLogConfigID` -> `ResolverQueryLogConfig`).

Generated with code-generator `v0.60.0` / runtime `v0.60.0`, `AWS_SDK_GO_VERSION=v1.34.0`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
